### PR TITLE
feat: PIZA4.4 Create CI job when create a PR

### DIFF
--- a/.github/workflows/pizza-planet-ci.yml
+++ b/.github/workflows/pizza-planet-ci.yml
@@ -1,0 +1,29 @@
+name: pizza-planet-ci
+
+on:
+  pull_request:
+    branches:
+    - "**"
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    
+    - name: Test with pytest
+      run: |
+        python manager.py test


### PR DESCRIPTION
## Description

**Type:** feature

Create a CI job with GitHub actions to run the tests and coverage when a PR is created. We want to be sure that test coverage does not decrease with new changes

## Files changed

- .github/workflows/pizza-planet-ci.yml

## Task board

- [PIZ4.4](https://trello.com/c/vpnozf2P)

## Acceptance criteria

- **Given** a PR **when** it is created **then** the pipeline is executed
