### PR TITLE
fix: PIZ4.4 CI job

### DIFF
--- a/.github/workflows/pizza-planet-ci.yml
+++ b/.github/workflows/pizza-planet-ci.yml
@@ -1,29 +1,34 @@
 name: pizza-planet-ci
 
 on:
+  push:
+    branches:
+    - "master"
+
   pull_request:
     branches:
     - "**"
 
 jobs:
-  ci:
+  build:
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
         python-version: ["3.10"]
-    
+
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-    
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    
+        pip install -r ./requirements.txt
+
     - name: Test with pytest
       run: |
-        python manager.py test
+        pytest


### PR DESCRIPTION
## Description

**Type:** feature

Create a CI job with GitHub actions to run the tests and coverage when a PR is created. We want to be sure that test coverage does not decrease with new changes

## Files changed

- .github/workflows/pizza-planet-ci.yml

## Task board

- [PIZ4.4](https://trello.com/c/vpnozf2P)

## Acceptance criteria

- **Given** a PR **when** it is created **then** the pipeline is executed

